### PR TITLE
[app] add `api` domain for backend

### DIFF
--- a/compose.app.yml
+++ b/compose.app.yml
@@ -17,6 +17,13 @@ services:
         - "traefik.http.routers.backend.rule=Host(`${BACKEND_HOST}`)"
         - "traefik.http.routers.backend.entrypoints=https"
         - "traefik.http.routers.backend.tls.certresolver=le"
+
+        - "traefik.http.middlewares.backend-api-addprefix.addprefix.prefix=/api"
+        - "traefik.http.routers.backend-api.rule=Host(`api.${BACKEND_HOST}`)"
+        - "traefik.http.routers.backend-api.entrypoints=https"
+        - "traefik.http.routers.backend-api.tls.certresolver=le"
+        - "traefik.http.routers.backend-api.middlewares=backend-api-addprefix"
+
         - "traefik.http.services.backend.loadbalancer.server.port=3000"
       replicas: 1
       resources:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced routing for the backend service with the addition of a new API prefix.
	- Introduced a new router for handling requests to the API subdomain.
	- Implemented HTTPS support with Let's Encrypt for secure connections.
	- Associated middleware for improved organization of API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->