### PR TITLE
[app] use direct connection from frontend to backend

### DIFF
--- a/compose.app.yml
+++ b/compose.app.yml
@@ -59,7 +59,7 @@ services:
       - HTTP__PROXY_HEADER=${HTTP__PROXY_HEADER}
       - HTTP__PROXIES=${HTTP__PROXIES}
       - QUEUE__URL=redis://redis:6379/0
-      - LINKS__URL=https://${BACKEND_HOST}/
+      - LINKS__URL=http://backend:3000/
       - LINKS__TIMEOUT=${BACKEND_TIMEOUT:-300ms}
     networks:
       - internal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the service connection configuration so that the frontend now directly references the backend via HTTP on a specified port for improved connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->