### PR TITLE
[monitoring] add monitoring stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,13 @@
+## Common
+ROOT_DOMAIN=example.com
+STACK_VERSION=1
+
+## App
 DASHBOARD_AUTH="admin:admin"
 DASHBOARD_HOST="admin.example.com"
 
 BACKEND_HOST="example.com"
+
+## Monitoring
+PROMETHEUS__IP_ALLOWLIST=10.0.0.0/8,172.16.0.0/12
+ALERTMANAGER__IP_ALLOWLIST=10.0.0.0/8,172.16.0.0/12

--- a/compose.monitoring.yml
+++ b/compose.monitoring.yml
@@ -1,0 +1,150 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.7.3
+    volumes:
+      - prometheus_data:/prometheus
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    configs:
+      - source: prometheus.yml
+        target: /etc/prometheus/prometheus.yml
+      - source: alert.rules.yml
+        target: /etc/prometheus/alert.rules.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    user: root
+    networks:
+      - internal
+      - public
+    deploy:
+      placement:
+        constraints:
+          - node.role==manager
+      resources:
+        limits:
+          memory: 256M
+      restart_policy:
+        condition: any
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=public"
+        - "traefik.http.routers.prometheus.rule=Host(`prometheus.${ROOT_DOMAIN}`)"
+        - "traefik.http.routers.prometheus.entrypoints=https"
+        - "traefik.http.routers.prometheus.tls.certresolver=le"
+        - "traefik.http.services.prometheus.loadbalancer.server.port=9090"
+        - "traefik.http.middlewares.prometheus-ipallowlist.ipallowlist.ipStrategy.depth=1"
+        - "traefik.http.middlewares.prometheus-ipallowlist.ipallowlist.sourcerange=${PROMETHEUS__IP_ALLOWLIST}"
+        - "traefik.http.routers.prometheus.middlewares=prometheus-ipallowlist"
+
+  alertmanager:
+    image: prom/alertmanager:v0.29.0
+    volumes:
+      - alertmanager_data:/alertmanager
+    configs:
+      - source: alertmanager.yml
+        target: /etc/alertmanager/alertmanager.yml
+    secrets:
+      - telegram_bot_token
+      - email_password
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    networks:
+      - internal
+      - public
+    deploy:
+      placement:
+        constraints:
+          - node.role==manager
+      resources:
+        limits:
+          memory: 128M
+      restart_policy:
+        condition: any
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=public"
+        - "traefik.http.routers.alertmanager.rule=Host(`alerts.${ROOT_DOMAIN}`)"
+        - "traefik.http.routers.alertmanager.entrypoints=https"
+        - "traefik.http.routers.alertmanager.tls.certresolver=le"
+        - "traefik.http.services.alertmanager.loadbalancer.server.port=9093"
+        - "traefik.http.middlewares.alertmanager-ipallowlist.ipallowlist.ipStrategy.depth=1"
+        - "traefik.http.middlewares.alertmanager-ipallowlist.ipallowlist.sourcerange=${ALERTMANAGER__IP_ALLOWLIST}"
+        - "traefik.http.routers.alertmanager.middlewares=alertmanager-ipallowlist"
+
+  # cadvisor:
+  #   image: gcr.io/cadvisor/cadvisor
+  #   volumes:
+  #     - /:/rootfs:ro
+  #     - /var/run:/var/run:rw
+  #     - /sys:/sys:ro
+  #     - /var/lib/docker/:/var/lib/docker:ro
+  #   networks:
+  #     - internal
+  #   deploy:
+  #     mode: global
+  #     restart_policy:
+  #       condition: any
+  #     labels:
+  #       - "prometheus.io/scrape=true"
+  #       - "prometheus.io/port=8080"
+  #       - "prometheus.io/job=cadvisor"
+
+  # grafana:
+  #   image: grafana/grafana
+  #   depends_on:
+  #     - prometheus
+  #   volumes:
+  #     - grafana_data:/var/lib/grafana
+  #     # - ./grafana/provisioning/:/etc/grafana/provisioning/
+  #   # env_file:
+  #   # - ./grafana/config.monitoring
+  #   networks:
+  #     - internal
+  #     - public
+  #   user: "472"
+  #   deploy:
+  #     placement:
+  #       constraints:
+  #         - node.role==manager
+  #     labels:
+  #       - "traefik.enable=true"
+  #       - "traefik.docker.network=public"
+  #       - "traefik.http.routers.grafana.rule=Host(`mon.${ROOT_DOMAIN}`)"
+  #       - "traefik.http.routers.grafana.entrypoints=https"
+  #       - "traefik.http.routers.grafana.tls.certresolver=le"
+  #       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+  #     restart_policy:
+  #       condition: any
+
+volumes:
+  prometheus_data: {}
+  alertmanager_data: {}
+  # grafana_data: {}
+
+networks:
+  public:
+    external: true
+  internal:
+    external: true
+
+configs:
+  prometheus.yml:
+    name: prometheus.yml_${STACK_VERSION:-0}
+    file: prometheus/prometheus.yml
+  alertmanager.yml:
+    name: alertmanager.yml_${STACK_VERSION:-0}
+    file: prometheus/alertmanager.yml
+  alert.rules.yml:
+    name: alert.rules.yml_${STACK_VERSION:-0}
+    file: prometheus/alert.rules.yml
+
+secrets:
+  telegram_bot_token:
+    name: telegram_bot_token
+    external: true
+  email_password:
+    name: email_password
+    external: true

--- a/prometheus/alert.rules.yml
+++ b/prometheus/alert.rules.yml
@@ -1,0 +1,58 @@
+groups:
+  - name: example-alerts
+    rules:
+      - alert: InstanceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Instance {{ $labels.instance }} down"
+          description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than 1 minute."
+
+      - alert: HighCPUUsage
+        expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High CPU usage on {{ $labels.instance }}"
+          description: "CPU usage on {{ $labels.instance }} has been above 80% for more than 2 minutes."
+
+  - name: backend-alerts
+    rules:
+      - alert: BackendHighLinkCreationErrorRate
+        expr: rate(links_errors_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High link creation error rate on {{ $labels.instance }}"
+          description: "The rate of link creation errors on {{ $labels.instance }} is {{ $value | humanizePercentage }}."
+
+      - alert: BackendIncreasedLatency
+        expr: histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, instance)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Increased latency on {{ $labels.instance }}"
+          description: "The 99th percentile latency on {{ $labels.instance }} is {{ $value }}s."
+
+      - alert: BackendHighHTTPRequestRate
+        expr: sum(rate(http_requests_total[5m])) by (status_code) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High HTTP request rate for status {{ $labels.status_code }}"
+          description: "HTTP request rate for status {{ $labels.status_code }} is {{ $value | humanize }}req/s."
+
+      - alert: BackendHighLinkRedirects
+        expr: rate(stats_redirects_total[5m]) > 1000
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: "High link redirect rate on {{ $labels.instance }}"
+          description: "The redirect rate on {{ $labels.instance }} is {{ $value | humanize }}req/s."

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -1,0 +1,36 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  group_by: ["alertname"]
+  group_wait: 10s
+  group_interval: 10s
+  repeat_interval: 1h
+  receiver: "default-receiver"
+  routes:
+    - receiver: "telegram"
+      match:
+        severity: "critical"
+    - receiver: "email"
+      match:
+        severity: "warning"
+    - receiver: "email"
+      match:
+        severity: "info"
+
+receivers:
+  - name: "default-receiver"
+  - name: "telegram"
+    telegram_configs:
+      - bot_token_file: /run/secrets/telegram_bot_token
+        chat_id: -1003253714088
+        send_resolved: true
+  - name: "email"
+    email_configs:
+      - from: "alerts@tnfy.link"
+        to: "admin@tnfy.link"
+        smarthost: "smtp.spaceweb.ru:587"
+        auth_username: "alerts@tnfy.link"
+        auth_identity: "alerts@tnfy.link"
+        auth_password_file: /run/secrets/email_password
+        send_resolved: true

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,97 @@
+global:
+  scrape_interval: 15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  # external_labels:
+  #     monitor: 'my-project'
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.rules.yml"
+
+# alert
+alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+        - targets:
+            - "alertmanager:9093"
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+
+  - job_name: "prometheus"
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 15s
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  # Create a job for Docker Swarm containers.
+  - job_name: "dockerswarm"
+    dockerswarm_sd_configs:
+      - host: unix:///var/run/docker.sock
+        role: tasks
+        filters:
+          - name: label
+            values:
+              - prometheus.io/scrape=true
+
+    relabel_configs:
+      # Only keep running tasks
+      - source_labels: [__meta_dockerswarm_task_desired_state]
+        regex: running
+        action: keep
+
+      # Only keep tasks in internal network
+      - source_labels: [__meta_dockerswarm_network_name]
+        regex: ^internal$
+        action: keep
+
+      # Use node hostname + task slot to disambiguate replicas
+      - source_labels:
+          [__meta_dockerswarm_node_hostname, __meta_dockerswarm_task_slot]
+        regex: (.*);(.*)
+        replacement: $1/task-$2
+        target_label: instance
+
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_io_port]
+        regex: (\d+)
+        target_label: __port__
+        replacement: $1
+        action: replace
+
+      # Drop targets missing or producing an empty __port__ (missing or non-numeric prometheus.io/port)
+      - source_labels: [__port__]
+        regex: ^$
+        action: drop
+
+      # Strip port from task address to isolate IP
+      - source_labels: [__address__]
+        target_label: __address__
+        regex: (.+):(\d+)
+        replacement: $1
+        action: replace
+
+      # Reconstruct address using IP + custom port from label
+      # (Multiple source_labels are joined with semicolons)
+      - source_labels: [__address__, __port__]
+        target_label: __address__
+        regex: (.+);(\d+)
+        replacement: $1:$2
+        action: replace
+
+      # Set the job name based on the service label
+      - source_labels: [__meta_dockerswarm_service_label_prometheus_io_job]
+        target_label: job
+        regex: (.+)
+        replacement: $1
+
+      # Set service_name label
+      - source_labels: [__meta_dockerswarm_service_name]
+        target_label: service_name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a monitoring stack with Prometheus and Alertmanager, preconfigured alert rules covering instance availability, CPU, backend errors, latency, request rates, and redirects. Alerts route to Telegram and email; services are reachable via HTTPS with TLS and IP-allowlist support.

* **Configuration**
  * New env vars for root domain and stack versioning, IP allowlists, external secrets for Telegram and email, and persistent storage for metrics. Optional metrics/dashboard components included as stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->