### PR TITLE
[monitoring] add Perses instead of Grafana

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,9 @@ ROOT_DOMAIN=example.com
 STACK_VERSION=1
 
 ## App
-DASHBOARD_AUTH="admin:admin"
-DASHBOARD_HOST="admin.example.com"
-
 BACKEND_HOST="example.com"
 
 ## Monitoring
 PROMETHEUS__IP_ALLOWLIST=10.0.0.0/8,172.16.0.0/12
 ALERTMANAGER__IP_ALLOWLIST=10.0.0.0/8,172.16.0.0/12
+PERSES__BASIC_AUTH_USERS=admin:admin

--- a/compose.monitoring.yml
+++ b/compose.monitoring.yml
@@ -92,37 +92,49 @@ services:
   #       - "prometheus.io/port=8080"
   #       - "prometheus.io/job=cadvisor"
 
-  # grafana:
-  #   image: grafana/grafana
-  #   depends_on:
-  #     - prometheus
-  #   volumes:
-  #     - grafana_data:/var/lib/grafana
-  #     # - ./grafana/provisioning/:/etc/grafana/provisioning/
-  #   # env_file:
-  #   # - ./grafana/config.monitoring
-  #   networks:
-  #     - internal
-  #     - public
-  #   user: "472"
-  #   deploy:
-  #     placement:
-  #       constraints:
-  #         - node.role==manager
-  #     labels:
-  #       - "traefik.enable=true"
-  #       - "traefik.docker.network=public"
-  #       - "traefik.http.routers.grafana.rule=Host(`mon.${ROOT_DOMAIN}`)"
-  #       - "traefik.http.routers.grafana.entrypoints=https"
-  #       - "traefik.http.routers.grafana.tls.certresolver=le"
-  #       - "traefik.http.services.grafana.loadbalancer.server.port=3000"
-  #     restart_policy:
-  #       condition: any
+  perses:
+    image: persesdev/perses:v0.52.0
+    networks:
+      - public
+      - internal
+    environment:
+      - PERSES_PROVISIONING_INTERVAL=24h
+      - PERSES_PROVISIONING_FOLDERS_0=/provisioning
+    configs:
+      - source: perses.dashboard.yaml
+        target: /provisioning/dashboard.yaml
+    volumes:
+      - perses_data:/data
+    deploy:
+      placement:
+        constraints:
+          - node.role==manager
+      replicas: 1
+      restart_policy:
+        condition: any
+      resources:
+        limits:
+          memory: 256M
+      labels:
+        - "traefik.enable=true"
+        - "traefik.swarm.network=public"
+
+        # Router
+        - "traefik.http.routers.perses.rule=Host(`mon.${ROOT_DOMAIN}`)"
+        - "traefik.http.routers.perses.entrypoints=https"
+        - "traefik.http.routers.perses.tls.certresolver=le"
+
+        # Basic Auth Middleware
+        - "traefik.http.middlewares.perses-auth.basicauth.users=${PERSES__BASIC_AUTH_USERS}"
+        - "traefik.http.routers.perses.middlewares=perses-auth"
+
+        # Service
+        - "traefik.http.services.perses.loadbalancer.server.port=8080"
 
 volumes:
   prometheus_data: {}
   alertmanager_data: {}
-  # grafana_data: {}
+  perses_data: {}
 
 networks:
   public:
@@ -140,6 +152,9 @@ configs:
   alert.rules.yml:
     name: alert.rules.yml_${STACK_VERSION:-0}
     file: prometheus/alert.rules.yml
+  perses.dashboard.yaml:
+    name: perses.dashboard.yaml_${STACK_VERSION:-0}
+    file: perses/dashboard.yaml
 
 secrets:
   telegram_bot_token:

--- a/perses/dashboard.yaml
+++ b/perses/dashboard.yaml
@@ -1,0 +1,126 @@
+- kind: "GlobalDatasource"
+  metadata:
+    name: Prometheus
+  spec:
+    default: true
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        proxy:
+          kind: "HTTPProxy"
+          spec:
+            url: "http://prometheus:9090"
+            allowedEndpoints:
+              - endpointPattern: "/api/v1/labels"
+                method: "POST"
+              - endpointPattern: "/api/v1/series"
+                method: "POST"
+              - endpointPattern: "/api/v1/metadata"
+                method: "GET"
+              - endpointPattern: "/api/v1/query"
+                method: "POST"
+              - endpointPattern: "/api/v1/query_range"
+                method: "POST"
+              - endpointPattern: "/api/v1/label/([a-zA-Z0-9_-]+)/values"
+                method: "GET"
+
+- kind: "Project"
+  metadata:
+    name: tnfy.link
+
+- kind: Dashboard
+  metadata:
+    name: tnfy-link
+    project: tnfy.link
+  spec:
+    display:
+      name: tnfy.link
+    panels:
+      "0_0":
+        kind: Panel
+        spec:
+          display:
+            name: Active Goroutines
+            description: Number of active goroutines in the application
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    minStep: ""
+                    query: go_goroutines
+                    seriesNameFormat: "{{job}}"
+      "0_1":
+        kind: Panel
+        spec:
+          display:
+            name: Memory Usage (Allocated)
+            description: Memory allocated by the application in bytes
+          plugin:
+            kind: TimeSeriesChart
+            spec: {}
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    minStep: ""
+                    query: go_memstats_alloc_bytes
+                    seriesNameFormat: "{{job}}"
+      "0_2":
+        kind: Panel
+        spec:
+          display:
+            name: CPU Usage
+            description: CPU usage in seconds
+          plugin:
+            kind: TimeSeriesChart
+            spec:
+              yAxis:
+                format:
+                  unit: percent-decimal
+                label: ""
+                show: true
+          queries:
+            - kind: TimeSeriesQuery
+              spec:
+                plugin:
+                  kind: PrometheusTimeSeriesQuery
+                  spec:
+                    minStep: ""
+                    query: rate(process_cpu_seconds_total[$__rate_interval])
+                    seriesNameFormat: "{{job}}"
+    layouts:
+      - kind: Grid
+        spec:
+          display:
+            title: General Metrics
+            collapse:
+              open: true
+          items:
+            - x: 0
+              "y": 0
+              width: 8
+              height: 8
+              content:
+                $ref: "#/spec/panels/0_0"
+            - x: 8
+              "y": 0
+              width: 8
+              height: 8
+              content:
+                $ref: "#/spec/panels/0_1"
+            - x: 16
+              "y": 0
+              width: 8
+              height: 8
+              content:
+                $ref: "#/spec/panels/0_2"
+    variables: []
+    duration: 1d
+    refreshInterval: 30s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced Grafana with Perses v0.52.0 for monitoring, renamed the persistence volume, and updated deployment/routing.
  * Consolidated dashboard authentication to a single PERSES__BASIC_AUTH_USERS key and enabled basic-auth middleware.
  * Monitoring remains reachable at the same host via HTTPS/TLS with updated Traefik routing and service settings.

* **New Features**
  * Added a default Perses dashboard showing General Metrics panels for goroutines, memory allocation, and CPU usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->